### PR TITLE
fix:transform ring bug.

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/ScrollOfTransmutation.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/ScrollOfTransmutation.java
@@ -256,7 +256,7 @@ public class ScrollOfTransmutation extends InventoryScroll {
 		
 		n.level(0);
 		
-		int level = r.level();
+		int level = r.trueLevel();
 		if (level > 0) {
 			n.upgrade( level );
 		} else if (level < 0) {


### PR DESCRIPTION
if use ScrollOfTransmutation transform ring(with ArcaneResin level),its will get extra level(equal ArcaneResin level).
