### PR TITLE
fix RNGManipulator behavior

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/EbonyMimic.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/EbonyMimic.java
@@ -117,6 +117,7 @@ public class EbonyMimic extends Mimic {
 					((Armor) i).inscribe(null);
 				}
 				if (!(i instanceof MissileWeapon || i instanceof Artifact) && i.level() == 0 && Random.Int(2) == 0){
+					i.upgrade();
 					for (int i1 = 0; i1 < RNGManipulator.LuckBoost.luckBoost() / 5000; i1++)
 						i.upgrade();
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/GoldenMimic.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/GoldenMimic.java
@@ -105,6 +105,7 @@ public class GoldenMimic extends Mimic {
 					((Armor) i).inscribe(null);
 				}
 				if (!(i instanceof MissileWeapon || i instanceof Artifact) && i.level() == 0 && Random.Int(2) == 0){
+					i.upgrade();
 					for (int i1 = 0; i1 < RNGManipulator.LuckBoost.luckBoost() / 5000; i1++)
 						i.upgrade();
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Wandmaker.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Wandmaker.java
@@ -326,6 +326,7 @@ public class Wandmaker extends NPC {
 				given = false;
 				wand1 = (Wand) Generator.random(Generator.Category.WAND);
 				wand1.cursed = false;
+				wand1.upgrade();
 				for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 					wand1.upgrade();
 
@@ -339,6 +340,7 @@ public class Wandmaker extends NPC {
 					Generator.undoDrop(i);
 				}
 				wand2.cursed = false;
+				wand2.upgrade();
 				for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 					wand2.upgrade();
 				

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/CursedWand.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/CursedWand.java
@@ -485,6 +485,7 @@ public class CursedWand {
 							Generator.Category.RING, Generator.Category.ARTIFACT));
 				} while (result.cursed);
 				if (result.isUpgradable())
+					result.upgrade();
 					for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 						result.upgrade();
 				result.cursed = result.cursedKnown = true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/secret/SecretMazeRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/secret/SecretMazeRoom.java
@@ -110,6 +110,7 @@ public class SecretMazeRoom extends SecretRoom {
 		
 		//33% chance for an extra update.
 		if (Random.Int(3) == 0){
+			prize.upgrade();
 			for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 				prize.upgrade();
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/CryptRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/CryptRoom.java
@@ -86,6 +86,7 @@ public class CryptRoom extends SpecialRoom {
 
 		//if it isn't already cursed, give it a free upgrade
 		if (!prize.cursed){
+			prize.upgrade();
 			for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 				prize.upgrade();
 			//curse the armor, unless it has a glyph

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/PoolRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/PoolRoom.java
@@ -125,6 +125,7 @@ public class PoolRoom extends SpecialRoom {
 		
 		//33% chance for an extra update.
 		if (Random.Int(3) == 0){
+			prize.upgrade();
 			for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 				prize.upgrade();
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SacrificeRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SacrificeRoom.java
@@ -96,6 +96,7 @@ public class SacrificeRoom extends SpecialRoom {
 
 		//if it isn't already cursed, give it a free upgrade
 		if (!prize.cursed){
+			prize.upgrade();
 			for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 				prize.upgrade();
 			//curse the weapon, unless it has a glyph

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
@@ -196,6 +196,7 @@ public class SentryRoom extends SpecialRoom {
 
 		//33% chance for an extra update.
 		if (Random.Int(3) == 0){
+			prize.upgrade();
 			for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 				prize.upgrade();
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/TrapsRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/TrapsRoom.java
@@ -139,6 +139,7 @@ public class TrapsRoom extends SpecialRoom {
 
 		//33% chance for an extra update.
 		if (Random.Int(3) == 0){
+			prize.upgrade();
 			for (int i = 0; i < RNGManipulator.LuckBoost.luckBoost() / 5000; i++)
 				prize.upgrade();
 		}


### PR DESCRIPTION
RNGManipulator shouldn't remove necessarily exist extra level.

change RNGManipulator behavior to increase the extra level probability,then if the probability >= 100%,give more level(like RingOfArcana), might be a better way to do it.